### PR TITLE
fix typo in cluster-install.md

### DIFF
--- a/_docs/cluster/cluster-install.md
+++ b/_docs/cluster/cluster-install.md
@@ -123,7 +123,7 @@ sudo chown $(id -u):$(id -g) $HOME/.kube/config
 To enable kubeconfig for a single session instead simply run:
 
 ```
-export KUBECONFIG=/etc/kubernets/admin.conf
+export KUBECONFIG=/etc/kubernetes/admin.conf
 ```
 
 ### Pod Network


### PR DESCRIPTION
Fixed this typo in the cluster-install.md page.
It's caught me out a few times...