### PR TITLE
Add copy button functionality to code blocks

### DIFF
--- a/_layouts/docs2020.html
+++ b/_layouts/docs2020.html
@@ -2,6 +2,7 @@
 layout: default
 ---
 {% include home.html %}
+
 <div class="show-on-mobile-only">
     {% include mobile-docs-menu.html %}
 </div>
@@ -10,7 +11,7 @@ layout: default
         {% comment %}
         {% endcomment %}
             {% include doc-nav.html %}
-    </div> 
+    </div>
 
     <div class="docs-container flex-fill">
         <div id="content-container" class=" docs-content-container col {{ page.type }}" >
@@ -23,3 +24,6 @@ layout: default
     <div class="p-2 doc-menu-fixed-width-right">
     </div>
 </div>
+
+<script src="/js/clipboard.min.js"></script>
+<script src="/js/copy.js"></script>

--- a/css/styles.css
+++ b/css/styles.css
@@ -51,3 +51,24 @@
 .tech-paragraph {
 	padding: 0 25px;
 }
+
+/* Code block copy button */
+.copy-btn-container {
+  display: flex;
+  flex-direction: row-reverse;
+  background: #f5f2f0;
+  font-size: .8em;
+  margin-top: 1em;
+}
+
+.copy-btn {
+  color: #FFFFFF;
+  background-color: #007bff;
+  border: 0;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+
+.copy-btn:hover {
+  background-color: #0099FF;
+}

--- a/js/copy.js
+++ b/js/copy.js
@@ -1,0 +1,41 @@
+let codeBlocks = document.querySelectorAll('[data-add-copy-button]');
+let count = 0;
+
+codeBlocks.forEach((block) => {
+  let code = block.querySelector('code');
+
+  // Ensure we're in a code block.
+  if (block.tagName != 'PRE' || code == null) {
+    return;
+  }
+
+  code.setAttribute("id", "copycode" + count);
+
+  // Create the div that holds the copy button.
+  let div = document.createElement('div');
+  div.className = "copy-btn-container";
+
+  let btn = document.createElement('button');
+  btn.innerHTML = "Copy";
+  btn.className = "copy-btn";
+  btn.setAttribute("data-clipboard-action", "copy");
+  btn.setAttribute("data-clipboard-target", "#copycode" + count);
+  div.appendChild(btn);
+
+  // Remove padding from code block.
+  block.style.paddingTop = "0";
+  block.style.marginTop = "0";
+  block.parentNode.insertBefore(div, block);
+
+  count++;
+});
+
+let clipboard = new ClipboardJS('.copy-btn');
+
+clipboard.on('success', function(e) {
+    e.clearSelection();
+    e.trigger.innerHTML = "Copied!";
+    setTimeout(() => {
+      e.trigger.innerHTML = "Copy";
+    }, 1000);
+});


### PR DESCRIPTION
This allows one to add `{:data-add-copy-button='true'}` immediately after any code
block in your markdown to create a copy button in the top right corner.

This is designed so that no element without this attribute is modified. Further, if Javascript is disabled, there will be no changes in functionality to the SLATE website.

See pull request #83 for examples.
![demo](https://user-images.githubusercontent.com/1847933/99326327-5cc93500-2835-11eb-8a5e-debd2f79ecd5.gif)
