### PR TITLE
Set inline code blocks to select all

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -51,3 +51,10 @@
 .tech-paragraph {
 	padding: 0 25px;
 }
+
+:not(pre) > code {
+	user-select: all;
+	-webkit-user-select: all;
+	-moz-user-select: all;
+	-ms-user-select: all;
+}


### PR DESCRIPTION
Another quality of life change.
When selecting any portion of an inline code block (i.e. \`foo\` and not
\`\`\`foo\`\`\`), everything in the inline code block will be highlighted.

Pull request #84 should handle non-inline code blocks.
![demo](https://user-images.githubusercontent.com/1847933/99328599-a9af0a80-2839-11eb-9f29-509c83d97f96.gif)