### PR TITLE
Add more thorough instructions to SLATE on CloudLab blog post

### DIFF
--- a/_posts/2021-06-08-slate-on-cloudlab.md
+++ b/_posts/2021-06-08-slate-on-cloudlab.md
@@ -98,10 +98,7 @@ What you will need to set up and run a succesful SLATE Kubernetes cluster:
   1. a CloudLab experiment
   2. key for CloudLab
   3. `ansible_ssh_common_args` added to hosts.yaml
-  4. a public IP and an IP ranger for MetalLb
-  5. CertManager
-  6. approriate version for Kubernetes
-  7. appropriate Docker and Calico versions
+  4. public IP(s) and/or range for MetalLB
 
 What you will *not* need to set up a SLATE Kuberentes cluster on CloudLab:
   - set up behind a NAT

--- a/_posts/2021-06-08-slate-on-cloudlab.md
+++ b/_posts/2021-06-08-slate-on-cloudlab.md
@@ -1,6 +1,6 @@
 ---
 title: "Deploying a SLATE Cluster on CloudLab"
-overview: A guide to running a SLATE cluster on CloudLab.
+overview: A guide to creating and deploying a SLATE cluster on CloudLab.
 published: true
 permalink: blog/slate-on-cloudlab.html
 attribution: The SLATE Team
@@ -16,7 +16,7 @@ More information about CloudLab can be found [here](https://www.cloudlab.us/).
 <!--end_excerpt-->
 
 
-## SLATE on CloudLab Motivation
+## Why SLATE on CloudLab
 
 Running SLATE clusters on CloudLab enables researchers to quickly test and tweak many different parameters.
 For example, testing a network of SLATE clusters, with simulated experimental latency or real latency (provided by profiles that launch machines across multiple sites), is made possible by CloudLab.
@@ -27,7 +27,6 @@ SLATE's monitoring applications, including perfSONAR, can also be leveraged to u
 Additionally, being able to rapidly deploy SLATE clusters on CloudLab gives SLATE developers and users many useful capabilities.
 For example, new applications or new application configurations can be launched on temporary CloudLab clusters, but registered with the SLATE production API, providing a highly realistic yet safe environment for testing changes.
 Kubespray, the SLATE team's preferred cluster bring-up tool, can also be quickly tested, or easily tested at scale with many machines on CloudLab.
-
 
 ## Prerequisites
 
@@ -46,7 +45,6 @@ This token is for the SLATE production API, and corresponds with an API endpoint
 For more information about getting started with SLATE, consult our quick-start guide [here](https://slateci.io/docs/quickstart/).
 
 Additionally, comprehensive documentation for CloudLab can be found [here](http://docs.cloudlab.us/).
-
 
 ## Launching CloudLab Experiment
 
@@ -85,16 +83,59 @@ First, although many different Linux distributions can be used, the SLATE team r
 Second, an additional pool of floating public IP addresses must be allocated for ingress and OSG applications to work.
 The CloudLab documentation has instructions for this [here](http://docs.cloudlab.us/advanced-topics.html#%28part._dynamic-public-ip%29).*
 
-
-## Kubernetes Cluster Creation / SLATE Registration
+## Creating a Kubernetes Cluster
 
 Once our CloudLab experiment/instances have fully spun up, we can begin installing Kubernetes on the node(s).
 The SLATE team recommends that [Kubespray](https://kubespray.io/#/) be used for this.
 
 However, we need a few additional pieces of information before we begin configuring Kubespray.
 
+### Requirements
+
+This serves as an outline for setting up a SLATE Kubernetes cluster on CloudLab. For the specific commands or versions please refer to the SLATE Kubernetes Cluster Creation documentation [here](https://slateci.io/docs/cluster/automated/kubernetes-cluster-creation.html#run).
+
+What you will need to set up and run a succesful SLATE Kubernetes cluster:
+  1. a CloudLab experiment
+  2. key for CloudLab
+  3. `ansible_ssh_common_args` added to hosts.yaml
+  4. a public IP and an IP ranger for MetalLb
+  5. CertManager
+  6. approriate version for Kubernetes
+  7. appropriate Docker and Calico versions
+
+What you will *not* need to set up a SLATE Kuberentes cluster on CloudLab:
+  - set up behind a NAT
+  - IP for binding Kubernetes services
+
+## Setup
+
+When creating your `hosts.yaml` file, under `vars:` add `ansible_ssh_common_args:`. This should point to the location where your private key for CloudLab can be found.
+CloudLab does not require an IP for binding Kubernetes services. CloudLab does, however, require the IP address for SSH connections to the host, which can be found when setting up a CloudLab experiment.   
+
+The instructions for setting up the CertManager, as well as the Kubernetes, Docker, and Calico versions required, can be found in the Kubernetes Cluster Creation [here](https://slateci.io/docs/cluster/automated/kubernetes-cluster-creation.html#run).
+
+### Standard Configuration {#kcc-configure}
+
+These are the default configuration steps we provide for setting up a Kubernetes cluster on CloudLab.
+Where appropriate, non-standard configuration steps can be used.
+
 Using Kubespray will require you to know the IP address of your CloudLab node, as well as the additional IP addresses CloudLab has allocated for MetalLB.
-To find these, navigate to the "Manifest" tab of the CloudLab experiment page, which will be accessible as soon as your experiment has partially spun up.
+
+### MetalLB
+
+MetalLB is a service that dynamically provides additional IPs for various services on a SLATE cluster that require their own dedicated IP.
+To do this, MetalLB requires at least one publicly routable, floating (not assigned and separate from your machine address) IP address to give out.
+This first extra public IP will be assigned to an Nginx Ingress Controller, a standard SLATE component.
+If you would like to run additional services that also require dedicated IPs (e.g. most OSG applications), you will want to allocate MetalLB more than one IP.
+
+Usually, MetalLB is a required component for any SLATE cluster; however, there are some situations where it should not be deployed.
+If you are setting up a SLATE cluster behind any sort of NAT, you must disable MetalLB.
+
+Otherwise, deploy MetalLB by following these instructions.
+
+#### Locate IP address for CloudLab node
+
+To find the IP address of your CloudLab node, as well as the additional IP addresses CloudLab has allocated for MetalLB, navigate to the "Manifest" tab of the CloudLab experiment page, which will be accessible as soon as your experiment has partially spun up.
 
 First, scroll down to the line (or lines if you have multiple nodes) that look similar to this:
 ```xml
@@ -140,5 +181,3 @@ This must then be done outside of SLATE.
 ## Contact Us
 
 Contact the SLATE team [here](https://slateci.io/community/).
-
-


### PR DESCRIPTION
Closes #115 

- Added requirements for SLATE cluster creation on CloudLab, as well as what SLATE clusters on CloudLab don't need.
- In Setup, added a brief explanation of the `ansible_ssh_common_args:` param and why CloudLab needs it. 
- Also added a reminder to have a key to access CloudLab through ssh. 
- Added an overview of what MetalLb is since CloudLab works with it
- Moved some things around