### PR TITLE
Add missing copy buttons to slateci.io

### DIFF
--- a/_docs/apps/chart.md
+++ b/_docs/apps/chart.md
@@ -69,6 +69,7 @@ SquidConf:
   # within kubernetes clusters. 
   IPRange: 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
 ```  
+{:data-add-copy-button='true'}
 
 In this example you can see that there are only 6 non-SLATE settings to manipulate in order to deploy an instance of Frontier Squid. These are the settings most pertinent to the functionality of Frontier Squid, and provide enough flexibility for general users. The settings in the SLATE category are provided by the api at the time of deployment to appropriately reflect the environment that the application is being deployed to. These defaults are for localized testing purposes.
 
@@ -127,5 +128,6 @@ SLATE:
     GroupEmail: "group-email"
 ### SLATE-END ###
 ```
+{:data-add-copy-button='true'}
 
 To use any of these, simply add them to your `values.yaml` file between the `### SLATE-START ###` and `### SLATE-END ###` tags. The values they are assigned can here can be arbitrary, as they will be overridden at application install time by the correct values.

--- a/_docs/apps/container.md
+++ b/_docs/apps/container.md
@@ -31,6 +31,7 @@ Each SLATE application should reside in a separate Git repository in the [GitHub
 ├── README.md 
 └── .gitignore
 ```
+{:data-add-copy-button='true'}
 
 * `app`: Contains all the sources for the application. The main script should be called `entrypoint.sh` where appropriate.
 * `local-test`: Contains the deployment for a local [minikube](https://minikube.sigs.k8s.io/docs/).
@@ -59,9 +60,11 @@ Use the template below for single-image repositories in the chosen container reg
 ```text
 slateci/appname
 ```
+{:data-add-copy-button='true'}
 
 In the case where your repository has more than one image use the following template instead:
 
 ```text
 slateci/appname-componentname
 ```
+{:data-add-copy-button='true'}

--- a/_docs/apps/development_tools/cvmfs.md
+++ b/_docs/apps/development_tools/cvmfs.md
@@ -30,6 +30,7 @@ parameters:
   proxy: 0.42.42.42:3128
 reclaimPolicy: Delete
 ```
+{:data-add-copy-button='true'}
 
 * If `proxy` is not provided, the CVMFS client will default to using a direct connection to the repository.
 * A `tag` or `hash` parameter may also be provided, but not both. If not provided, `tag` will default to `trunk`.
@@ -53,6 +54,7 @@ spec:
       storage: 5Gi
   storageClassName: my-repo-sc
 ```
+{:data-add-copy-button='true'}
 
 What is important to note is that this claim is `ReadOnlyMany`. The claim must be `ReadOnly` or `ReadOnlyMany` because there are no write permission to the repository through the CVMFS client.
 
@@ -73,3 +75,4 @@ volumes:
     readOnly: true
 ...
 ```
+{:data-add-copy-button='true'}

--- a/_docs/apps/development_tools/local-storage.md
+++ b/_docs/apps/development_tools/local-storage.md
@@ -37,6 +37,7 @@ spec:
       storage: {% raw %}{{ .Values.LocalStorageSize }}{% endraw %}Gi
   storageClassName: nfs-provisioner
 ```  
+{:data-add-copy-button='true'}
 The important feature of this is the `storageClassName` which must match `nfs-provisioner`.
 
 The `pvc` is then mounted within the application deployment as a volume as follows:
@@ -53,6 +54,7 @@ volumes:
   persistentVolumeClaim:
     claimName: my-application-{% raw %}{{ .Values.Instance }}{% endraw %}-pvc
 ```
+{:data-add-copy-button='true'}
 
 ## Including a Node Affinity
 
@@ -64,3 +66,4 @@ nodeSelector:
   storage: "local"
 ...
 ```
+{:data-add-copy-button='true'}

--- a/_docs/apps/tutorial/kubernetes.md
+++ b/_docs/apps/tutorial/kubernetes.md
@@ -35,6 +35,7 @@ If you followed [the directions for installing MiniSLATE]({home}/docs/apps/tutor
       $ ./minislate start
       $ ./minislate shell slate
 ```
+{:data-add-copy-button='true'}
 
 This will put you within the MiniSLATE command shell and interact with the KubeCTL instance within your dev cluster.
 
@@ -125,6 +126,7 @@ containers:
 +     - name: nginx-mounted-volume
 +       emptyDir: {}
 ```
+{:data-add-copy-button='true'}
 
 [The Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/volumes/) has more information regarding volume integration.
 
@@ -147,6 +149,7 @@ volumes:
 configMap:
 name: demo-nginx-configmap
 ```
+{:data-add-copy-button='true'}
  Now that you've made the change, appy it with `$ kubectl apply -f firstDeployment.yaml`. If all has gone correctly, the container should restart with the index.html file mounted, and will be serving it. Try to recall how we accessed the NodePort service and give it a try! 
 
 ## Cleaning it Up

--- a/_docs/cluster/automated/install-kubernetes-with-kubespray.md
+++ b/_docs/cluster/automated/install-kubernetes-with-kubespray.md
@@ -185,6 +185,7 @@ k8s-cluster:
   vars:
     dns_min_replicas: 1
 ```
+{:data-add-copy-button='true'}
 
 ### Set specific Kubernetes versions
 
@@ -192,6 +193,7 @@ In `inventory/<CLUSTER_NAME>/group_vars/k8s-cluster/k8s-cluster.yml` set
 ```yaml
 kube_version: v1.18.10
 ```
+{:data-add-copy-button='true'}
 
 ### Set specific Docker and Calico versions
 
@@ -202,6 +204,7 @@ k8s-cluster:
     docker_version: latest
     calico_version: "v3.16.4"
 ```
+{:data-add-copy-button='true'}
 
 ### Disable MetalLB
 

--- a/_docs/cluster/automated/kubernetes-cluster-creation.md
+++ b/_docs/cluster/automated/kubernetes-cluster-creation.md
@@ -158,6 +158,7 @@ k8s-cluster:
   vars:
     dns_min_replicas: 1
 ```
+{:data-add-copy-button='true'}
 
 #### Set specific Kubernetes versions
 
@@ -165,6 +166,7 @@ In `inventory/<CLUSTER_NAME>/group_vars/k8s-cluster/k8s-cluster.yml` set
 ```yaml
 kube_version: v1.18.10
 ```
+{:data-add-copy-button='true'}
 
 #### Set specific Docker and Calico versions
 
@@ -175,6 +177,7 @@ k8s-cluster:
     docker_version: latest
     calico_version: "v3.16.4"
 ```
+{:data-add-copy-button='true'}
 
 #### Disable MetalLB
 
@@ -290,6 +293,7 @@ Add the following two flags to your SLATE registration playbook command if your 
 -e 'cluster_access_ip=<EXTERNAL_NAT_IP>:6443' \
 -e 'slate_enable_ingress=false'
 ```
+{:data-add-copy-button='true'}
 
 *Note that `EXTERNAL_NAT_IP` is the IP at which your node is publicly accessible.*
 

--- a/_docs/cluster/manual/cluster-federation.md
+++ b/_docs/cluster/manual/cluster-federation.md
@@ -23,6 +23,7 @@ On the Master node for your cluster (or a system with kubectl configured with ad
 ```
 slate cluster create [NEW-CLUSTER-NAME] --group [YOUR-GROUP-NAME] --org [YOUR-ORG-NAME] -y
 ```
+{:data-add-copy-button='true'}
 
 ### Update Cluster Location
 
@@ -31,6 +32,7 @@ All SLATE clusters should have their geographic locations listed in the cluster'
 ```
 slate cluster update [YOUR-CLUSTER-NAME] --location [LATITUDE],[LONGITUDE]
 ```
+{:data-add-copy-button='true'}
 
 ### Allow Group Access
 
@@ -39,5 +41,6 @@ Cluster administrators can grant cluster access to specific groups.
 ```
 slate cluster allow-group [YOUR-CLUSTER-NAME] '[GROUP-NAME]'
 ```
+{:data-add-copy-button='true'}
 
 <a href="/docs/cluster/manual/troubleshooting.html">Next Page</a>

--- a/_docs/cluster/manual/kubernetes.md
+++ b/_docs/cluster/manual/kubernetes.md
@@ -26,6 +26,7 @@ repo_gpgcheck=0
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 ```
+{:data-add-copy-button='true'}
 
 **Note** If you get an error about GPG keys, Google's recommendation is changing above file entry to `repo_gpgcheck=0`.  Currently (03/30/2022) the Google GPG key is expired or incorrect for yum installs. For more information please visit Google's [Known Issues](https://cloud.google.com/compute/docs/troubleshooting/known-issues#keyexpired) page. 
 
@@ -43,6 +44,7 @@ Install and enable these components:
 KUBE_VERSION=1.24.* && \
 yum install -y kubeadm-${KUBE_VERSION} kubectl-${KUBE_VERSION} kubelet-${KUBE_VERSION} --disableexcludes=kubernetes
 ```
+{:data-add-copy-button='true'}
 
 ### Finish Up
 
@@ -51,6 +53,7 @@ Finally, enable kubelet:
 ```
 systemctl enable --now kubelet
 ```
+{:data-add-copy-button='true'}
 
 At this point the kubelet will be crash-looping as it has no configuration. That is okay for now.
 

--- a/_docs/cluster/manual/operating-system-requirements.md
+++ b/_docs/cluster/manual/operating-system-requirements.md
@@ -17,6 +17,7 @@ First, you will need to disable SELinux as this generally conflicts with Kuberne
 setenforce 0
 sed -i --follow-symlinks 's/SELINUX=enforcing/SELINUX=disabled/g' /etc/sysconfig/selinux
 ```
+{:data-add-copy-button='true'}
 
 If you wish to retain the SELinux logging, you can alternatively use 'permissive' mode rather than enforcing.
 
@@ -27,6 +28,7 @@ Swap must be disabled for Kubernetes to run effectively. Swap is typically enabl
 swapoff -a
 sed -e '/swap/s/^/#/g' -i /etc/fstab
 ```
+{:data-add-copy-button='true'}
 
 ### Disable firewalld
 In order to properly communicate with other devices within the cluster, `firewalld` must be disabled:
@@ -34,6 +36,7 @@ In order to properly communicate with other devices within the cluster, `firewal
 ```
 systemctl disable --now firewalld
 ```
+{:data-add-copy-button='true'}
 
 ### Disable root login over SSH
 While optional, we *strongly* recommend disabling root login over SSH for security reasons.
@@ -41,6 +44,7 @@ While optional, we *strongly* recommend disabling root login over SSH for securi
 ```
 sed -i --follow-symlinks 's/#PermitRootLogin yes/PermitRootLogin no/g' /etc/ssh/sshd_config
 ```
+{:data-add-copy-button='true'}
 
 ### Use iptables for Bridged Network Traffic
 Ensure that bridged network traffic goes through iptables.
@@ -52,11 +56,13 @@ net.bridge.bridge-nf-call-iptables = 1
 EOF
 sysctl --system
 ```
+{:data-add-copy-button='true'}
 
 ### Enable routing
 
 ```
 echo 1 > /proc/sys/net/ipv4/ip_forward
 ```
+{:data-add-copy-button='true'}
 
 <a href="/docs/cluster/manual/containerd.html">Next Page</a>

--- a/_docs/cluster/manual/slate-master-node.md
+++ b/_docs/cluster/manual/slate-master-node.md
@@ -23,6 +23,7 @@ We want to initialize our cluster with the pod network CIDR specifically set to 
 ```
 kubeadm init --pod-network-cidr=192.168.0.0/16
 ```
+{:data-add-copy-button='true'}
 
 ### KubeConfig
 
@@ -33,12 +34,14 @@ mkdir -p $HOME/.kube
 sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 ```
+{:data-add-copy-button='true'}
 
 To enable kubeconfig for a single session instead simply run:
 
 ```
 export KUBECONFIG=/etc/kubernetes/admin.conf
 ```
+{:data-add-copy-button='true'}
 
 ### Allowing pods to run on the Master
 **NOTE**: *This step is OPTIONAL for multi-node installations of Kubernetes, but REQUIRED for single-node installations.*
@@ -50,6 +53,7 @@ To remove the master taint:
 ```
 kubectl taint nodes --all node-role.kubernetes.io/control-plane:NoSchedule-
 ```
+{:data-add-copy-button='true'}
 
 ### Pod Network
 
@@ -63,6 +67,7 @@ To install Calico, you will simply need to apply the appropriate Kubernetes mani
 kubectl create -f https://docs.projectcalico.org/manifests/tigera-operator.yaml
 kubectl create -f https://docs.projectcalico.org/manifests/custom-resources.yaml
 ```
+{:data-add-copy-button='true'}
 
 After approximately five minutes, your master node should be ready. You can check with `kubectl get nodes`:
 
@@ -71,6 +76,7 @@ After approximately five minutes, your master node should be ready. You can chec
 NAME                           STATUS   ROLES                  AGE     VERSION
 your-node.your-domain.edu   Ready    control-plane,master   2m50s   v1.24.0
 ```
+{:data-add-copy-button='true'}
 
 ### Load Balancer
 
@@ -84,6 +90,7 @@ Apply MetalLB to our cluster. This command will create the relevant kubernetes c
 kubectl create -f https://raw.githubusercontent.com/metallb/metallb/v0.11.0/manifests/namespace.yaml
 kubectl create -f https://raw.githubusercontent.com/metallb/metallb/v0.11.0/manifests/metallb.yaml
 ```
+{:data-add-copy-button='true'}
 
 Create the MetalLB configuration and adjust the IP range to reflect your environment. These must be unallocated public IP addresses available to the machine.
 
@@ -103,12 +110,14 @@ data:
       - 155.101.6.XXX-155.101.6.YYY # Replace this range with whatever IP range your worker nodes may exist in
 EOF
 ```
+{:data-add-copy-button='true'}
 
 Finally, create the ConfigMap for MetalLB on your cluster.
 
 ```
 kubectl apply -f metallb-config.yaml
 ```
+{:data-add-copy-button='true'}
 
 To read more about MetalLB installation and configuration, visit their [installation instructions](https://metallb.universe.tf/installation/).
 

--- a/_docs/cluster/manual/slate-token.md
+++ b/_docs/cluster/manual/slate-token.md
@@ -28,6 +28,7 @@ To check that the SLATE client is ready to use, you can run:
 ```shell
 slate cluster list
 ```
+{:data-add-copy-button='true'}
 
 This should list the various clusters which are already participating in the federation.
 

--- a/_docs/cluster/manual/slate-worker-node.md
+++ b/_docs/cluster/manual/slate-worker-node.md
@@ -19,6 +19,7 @@ On your Master node, run the following command to get a full join command for th
 ```
 kubeadm token create --print-join-command
 ```
+{:data-add-copy-button='true'}
 
 Run this generated join command on the worker node to join it to the cluster.
 

--- a/_posts/2020-01-01-how-to-post-a-blog.md
+++ b/_posts/2020-01-01-how-to-post-a-blog.md
@@ -36,6 +36,7 @@ layout: post
 type: markdown
 ---
 ```
+{:data-add-copy-button='true'}
 
 If you want to see the blog post as it would be published, but are not ready to publish to the webiste's blog page, you can add an additional entry in the front matter then view the post at [https://slateci.io/drafts/](https://slateci.io/drafts/). 
 
@@ -44,6 +45,7 @@ Add the following to the the front matter to view the blog in the drafts section
 ```
 tag: draft
 ```
+{:data-add-copy-button='true'}
 
 #### Images
 
@@ -52,6 +54,7 @@ To Include an image in the blog post, place the image in img/posts and link to i
 ```
 ![Alt Text](/img/posts/image-name.png)
 ```
+{:data-add-copy-button='true'}
 
 #### Excerpt
 
@@ -60,5 +63,6 @@ How much of the blog post that is displayed on the Blog page (slateci.io/blog) i
 ```
 <!--end_excerpt-->
 ```
+{:data-add-copy-button='true'}
 
 Feel free to look at other blog posts in the [github repository](https://github.com/slateci/slateci.github.io) for examples. 

--- a/_posts/2020-07-20-stashcache.md
+++ b/_posts/2020-07-20-stashcache.md
@@ -24,12 +24,14 @@ First, you'll want to get the configuration for the StashCache application:
 ```bash
 slate app get-conf stashcache > stashcache.yaml
 ```
+{:data-add-copy-button='true'}
 
 Open it in your favorite editor, e.g. vim:
 
 ```bash
 vim stashcache.yaml
 ```
+{:data-add-copy-button='true'}
 
 You'll want to make changes in 4 sections. First, change the Instance tag to something memorable. I used "iu-mwt2".
 ```yaml
@@ -37,6 +39,7 @@ You'll want to make changes in 4 sections. First, change the Instance tag to som
 # Results in a name like "stashcache-[Instance]"
 Instance: "iu-mwt2"
 ```
+{:data-add-copy-button='true'}
 
 ### Configuring the host
 If you want to use this cache for real data, you'll want to point StashCache at some directory on your _host_ system, from which StashCache will serve data. 
@@ -49,12 +52,14 @@ StashCache:
   # contents will be lost any time the application is restarted.
   CacheDirectory: /slate-cache
 ```
+{:data-add-copy-button='true'}
 
 While you're here, you may want to change other options as well. Since this will be a production cache, I increased the `RamSize` from the default 1GB to 64GB:
 ```yaml
   # The amount of memory the cache is allowed to use (in GB)
   RamSize: 64g
 ```
+{:data-add-copy-button='true'}
 
 ### Configuring & installing the certificate
 
@@ -64,6 +69,7 @@ To install the certificate to the cluster, you'll need to use the `slate secret`
 ```bash
 slate secret create stashcache-cert --from-file=hostcert.pem --from-file=hostkey.pem
 ```
+{:data-add-copy-button='true'}
 
 Then, you'll want to take the secret name and put that into the StashCache config file:
 ```yaml
@@ -75,6 +81,7 @@ Then, you'll want to take the secret name and put that into the StashCache confi
 # Leaving this as the empty string will disable the authenticated cache.
 hostCertSecret: stashcache-cert
 ```
+{:data-add-copy-button='true'}
 
 It's possible to install StashCache without an IGTF certificate, however you will not be able to federate your cache with the OSG federation. 
 
@@ -85,6 +92,7 @@ Finally, once you have configured the StashCache application to your satisfactio
 ```bash
 slate app install stashcache --conf stashcache.yaml --group <your group> --cluster <your cluster>
 ```
+{:data-add-copy-button='true'}
 
 If all goes well, SLATE will successfully install the cache and give you an instance ID. You can use that ID to check the status
 ```bash
@@ -98,12 +106,14 @@ Name                          Cluster IP     External IP     Ports          URL
 stashcache-mwt2-iu-test-http  10.105.253.127 149.165.225.214 8000:31612/TCP 149.165.225.214:31612
 stashcache-mwt2-iu-test-xroot 10.108.181.32  149.165.225.214 1094:32009/TCP 149.165.225.214:32009
 ```
+{:data-add-copy-button='true'}
 
 From the URL field reported by SLATE, you can run a test to ensure your cache is working over the HTTP protocol:
 ```bash
  $ curl http://149.165.225.214:31612/osgconnect/public/rynge/test.data
 hello world!
 ```
+{:data-add-copy-button='true'}
 
 ## Registering your cache in the OSG Topology system
 

--- a/_posts/2020-10-14-Network-Policy-Creation.md
+++ b/_posts/2020-10-14-Network-Policy-Creation.md
@@ -23,6 +23,7 @@ NetworkPolicy:
   AllowedCIDRs: 
     - 0.0.0.0/0
 ```
+{:data-add-copy-button='true'}
 
 The first setting, Enabled, defines wether or not a network policy is created. By default this is false and no policy is created. The second setting is the list of CIDRs whitelisted by the network policy. The default CIDR of `0.0.0.0/0` creates a policy that allows all traffic.
     

--- a/_posts/2020-10-28-telegraf-monitoring.md
+++ b/_posts/2020-10-28-telegraf-monitoring.md
@@ -44,6 +44,7 @@ yum install net-snmp net-snmp-utils
 systemctl enable snmpd
 systemctl restart snmpd
 ```
+{:data-add-copy-button='true'}
 More details can be found [here](https://support.managed.com/kb/a2390/how-to-install-snmp-and-configure-the-community-string-for-centos.aspx).
 
  
@@ -54,6 +55,7 @@ The SLATE client provides a simple way to do this with the command below:
 ```bash
 slate app get-conf telegraf > telegraf.yaml
 ```
+{:data-add-copy-button='true'}
 
 This will save a local copy of the Telegraf configuration, formatted as a .yaml file.
 We will modify this configuration accordingly, and eventually deploy the application with this configuration.
@@ -73,6 +75,7 @@ Once you have credentials, store the password in a SLATE secret by running the f
 ```bash
 slate secret create --group <slate_group> --cluster <slate_cluster> --from-literal password=<your_password> <secret_name>
 ```
+{:data-add-copy-button='true'}
 Make a note of the name you gave this secret, as we will use it later.
 
 Next, configure the database endpoint by filling out the `grnocOutput` section with the hostname, username, and secret name that you setup earlier.
@@ -84,6 +87,7 @@ grnocOutput:
   username: "tsds_username"
   passwordSecretName: "secret_name"
 ```
+{:data-add-copy-button='true'}
 
 Note that if GRNOC output is enabled, you will not be able to specify a custom set of OIDs. 
 An OID is an identifier specifying a metric to monitor. More information can be found [here](https://www.ittsystems.com/snmp-oid-versions-functionality/).
@@ -172,6 +176,7 @@ For example, to collect metrics every five seconds, enter the following:
 ```yaml
 collectionInterval: 5s
 ```
+{:data-add-copy-button='true'}
 The `collectionInterval` parameter is paired with a `collectionJitter` parameter.
 This `collectionJitter` parameter will offset data collection times by a random amount not exceeding its value.
 
@@ -211,6 +216,7 @@ To install the application onto a SLATE cluster, simply run the command below:
 ```bash
 slate app install telegraf --group <group_name> --cluster <cluster_name> --conf telegraf.yaml
 ```
+{:data-add-copy-button='true'}
 This installs the Telegraf application onto the cluster specified, with the configuration previously specified.
 
 
@@ -223,6 +229,7 @@ On the machine you want to receive metrics on, enter the command:
 ```bash
 nc -lk 9999
 ```
+{:data-add-copy-button='true'}
 This will listen for any incoming data on port 9999.
 Then, configure the InfluxDB endpoint to point to port 9999 on this machine. Enter something like this:
 ```yaml
@@ -231,6 +238,7 @@ influxOutput:
   endpoint: "http://<machine_ip_here>:9999"
   database: "telegraf"
 ```
+{:data-add-copy-button='true'}
 
 
 ### Testing with InfluxDB
@@ -240,10 +248,12 @@ Configure Docker on the machine you want to receive metrics on, and pull the Inf
 ```bash
 docker pull influxdb
 ```
+{:data-add-copy-button='true'}
 Next, run the image in a container with the appropriate ports and volumes:
 ```bash
 docker run -p 9999:9999 -v $PWD:/var/lib/influxdb influxdb
 ```
+{:data-add-copy-button='true'}
 
 Configure Telegraf's InfluxDB output to push over http to this endpoint on port 9999.
 
@@ -255,12 +265,14 @@ In the event that something is not working properly, logs from the container run
 ```bash
 slate instance logs <instance_id>
 ```
+{:data-add-copy-button='true'}
 An `instance_id` is a unique, randomly-generated string prefaced with "instance" that SLATE assigns to each running experiment.
 This ID is printed on app installation. 
 Additionally, a list of running applications and their IDs can be printed with the command:
 ```bash
 slate instance list
 ```
+{:data-add-copy-button='true'}
 
 For additional help, or to report a bug, please contact the [SLATE team](https://slateci.io/community/).
 

--- a/_posts/2021-02-08-open-ondemand.md
+++ b/_posts/2021-02-08-open-ondemand.md
@@ -43,6 +43,7 @@ obtained. The SLATE client will do this with the following command:
 ```bash
 slate app get-conf open-ondemand > ood.yaml
 ```
+{:data-add-copy-button='true'}
 
 This will save a local copy of the OnDemand configuration, formatted as a
 .yaml file. We will modify this configuration accordingly, and eventually
@@ -63,6 +64,7 @@ to
 ```yaml
 cert_manager_enabled: true
 ```
+{:data-add-copy-button='true'}
 More information on using Ansible playbooks can be found [here](https://slateci.io/docs/cluster/install-kubernetes-with-kubespray.html).
 If the administrator has access to `kubectl` then cert-manager can be installed using a regular manifest or with helm. Instructions can be found at the official [cert-manager docs](https://cert-manager.io/docs/installation/kubernetes/).
 
@@ -82,6 +84,7 @@ spec:
     privateKeySecretRef:
       name: lets-encrypt-key
 ```
+{:data-add-copy-button='true'}
 Make sure that the name of the issuer is `letsencrypt-prod`.
 
 Note: The difference between a `ClusterIssuer` and an `Issuer` is that the latter is namespace specific.
@@ -130,6 +133,7 @@ To install the application using slate, run this app install command:
 ```bash
 slate app install open-ondemand --group <group_name> --cluster <cluster_name> --conf /path/to/ood.yaml
 ```
+{:data-add-copy-button='true'}
 
 ## Testing
 
@@ -154,6 +158,7 @@ section for each user you would like to add:
     name: <username_here>
     tempPassword: <temporary_password_here>
 ```
+{:data-add-copy-button='true'}
 
 ## Configurable Parameters:
 

--- a/_posts/2021-06-08-grnoc-telegraf-monitoring.md
+++ b/_posts/2021-06-08-grnoc-telegraf-monitoring.md
@@ -51,6 +51,7 @@ yum install net-snmp net-snmp-utils
 systemctl enable snmpd
 systemctl restart snmpd
 ```
+{:data-add-copy-button='true'}
 More details can be found [here](https://support.managed.com/kb/a2390/how-to-install-snmp-and-configure-the-community-string-for-centos.aspx).
 
  
@@ -61,6 +62,7 @@ The SLATE client provides a simple way to do this with the command below:
 ```bash
 slate app get-conf grnoc-telegraf > grnoc-telegraf.yaml
 ```
+{:data-add-copy-button='true'}
 
 This will save a local copy of the Telegraf configuration, formatted as a .yaml file.
 We will modify this configuration accordingly, and eventually deploy the application with this configuration.
@@ -79,6 +81,7 @@ Once you have credentials, store the password in a SLATE secret by running the f
 ```bash
 slate secret create --group <slate_group> --cluster <slate_cluster> --from-literal password=<your_password> <secret_name>
 ```
+{:data-add-copy-button='true'}
 Make a note of the name you gave this secret, as we will use it later.
 
 Next, configure the database endpoint by filling out the `grnocOutput` section with the hostname, username, and secret name that you setup earlier.
@@ -89,6 +92,7 @@ grnocOutput:
   username: "tsds_username"
   passwordSecretName: "secret_name"
 ```
+{:data-add-copy-button='true'}
 
 ### Target Configuration
 
@@ -163,6 +167,7 @@ For example, to collect metrics every five seconds, enter the following:
 ```yaml
 collectionInterval: 5s
 ```
+{:data-add-copy-button='true'}
 The `collectionInterval` parameter is paired with a `collectionJitter` parameter.
 This `collectionJitter` parameter will offset data collection times by a random amount not exceeding its value.
 
@@ -202,6 +207,7 @@ To install the application onto a SLATE cluster, simply run the command below:
 ```bash
 slate app install grnoc-telegraf --group <group_name> --cluster <cluster_name> --conf telegraf.yaml
 ```
+{:data-add-copy-button='true'}
 This installs the `grnoc-telegraf` application onto the cluster specified, with the configuration previously specified.
 
 After installation, metrics will be pushed to the [GlobalNOC database](https://tsds.wash2.net.internet2.edu/community/?method=browse&measurement_type=interface).
@@ -215,12 +221,14 @@ In the event that something is not working properly, logs from the container run
 ```bash
 slate instance logs <instance_id>
 ```
+{:data-add-copy-button='true'}
 An `instance_id` is a unique, randomly-generated string prefaced with "instance" that SLATE assigns to each running experiment.
 This ID is printed on app installation. 
 Additionally, a list of running applications and their IDs can be printed with the command:
 ```bash
 slate instance list
 ```
+{:data-add-copy-button='true'}
 
 For additional help, or to report a bug, please contact the [SLATE team](https://slateci.io/community/).
 

--- a/_posts/2021-06-14-chameleon-stitched-clusters.md
+++ b/_posts/2021-06-14-chameleon-stitched-clusters.md
@@ -36,6 +36,7 @@ It can be downloaded with the following command:
 ```bash
 pip install git+https://github.com/ChameleonCloud/python-blazarclient.git
 ```
+{:data-add-copy-button='true'}
 It is important to be aware of different client versions, as Chameleon expects version `2.2.2` to be used.
 
 
@@ -60,6 +61,7 @@ First, authenticate with a Chameleon site by running this command:
 ```bash
 source /path/to/openrc.sh
 ```
+{:data-add-copy-button='true'}
 This `openrc.sh` file is the application credential you created earlier.
 You should have one for each site.
 
@@ -67,6 +69,7 @@ Then, use the following command to create a network lease:
 ```bash
 `blazar lease-create --reservation resource_type=network,network_name=<network_name_here>,resource_properties='["==","$physical_network","exogeni"]' --start-date <start_date> --end-date "<end_date>" <lease_name>`
 ```
+{:data-add-copy-button='true'}
 Note that the start and end date parameters must include a time as well.
 The time and date should be specified with the following format:
 ```bash
@@ -194,6 +197,7 @@ Open this file on both nodes, and append the following lines:
 <node_1_internal_ip> cluster1.slateci.net
 <node_2_internal_ip> cluster2.slateci.net
 ```
+{:data-add-copy-button='true'}
 The internal IP of each node can be found from each node's respective web portal.
 These IPs will be assigned from the `192.168.1.0/24` subnet that we created earlier.
 
@@ -218,16 +222,19 @@ If `iperf` is not already installed, it can be installed with:
 ```bash
 sudo yum install iperf
 ```
+{:data-add-copy-button='true'}
 Note that both nodes will need to have `iperf` installed.
 
 Afterwards, run an iPerf server on the first node with this command:
 ```bash
 iperf -s
 ```
+{:data-add-copy-button='true'}
 Then, run the iPerf client on the second node and connect to the server on the first node with this command:
 ```bash
 iperf -c <node_1_internal_ip>
 ```
+{:data-add-copy-button='true'}
 After a little while, the test will complete, and you should see bandwidth results.
 If desired, you can run this test in reverse by swapping the locations of the client and server.
 Alternately, iPerf's `-r` or `-d` options can be used for running bi-directional tests.
@@ -240,12 +247,14 @@ Do this with the following command wherever you have the slate client available:
 ```bash
 slate app install perfsonar-testpoint --cluster <cluster_2> --group <your_group>
 ```
+{:data-add-copy-button='true'}
 
 The `perfsonar-checker` application will require a small amount of configuration.
 First, to fetch its configuration file, run:
 ```bash
 slate app get-conf --dev perfsonar-checker > perfsonar-checker.conf
 ```
+{:data-add-copy-button='true'}
 Navigate to the `Instance` section, and give your application an appropriate instance tag.
 Next, navigate to the `PerfsonarChecker` section, and change the `Dest1` parameter to the appropriate hostname that was set up earlier in `/etc/hosts/`.
 The `Dest2` and `Dest3` values can be commented out, or left as-is, if you would also like to run tests to those endpoints.
@@ -254,12 +263,14 @@ Now, we are ready to install this application with this command:
 ```bash
 slate app install --dev perfsonar-checker --cluster <cluster_1> --group <your_group> --conf perfsonar-checker.conf
 ```
+{:data-add-copy-button='true'}
 After the application finishes installing, an instance ID will be printed out.
 Take note of this ID.
 Then, give the application some time to run, and check the results with this command:
 ```bash
 slate instance logs --max-lines 0 <perfsonar_checker_instance_id>
 ```
+{:data-add-copy-button='true'}
 More information about perfSONAR and the expected results can be found in the [PerfSONAR Checker Blog Post](https://slateci.io/blog/perfsonar-checker.html).
 
 

--- a/_posts/2021-06-29-slate-on-chameleon.md
+++ b/_posts/2021-06-29-slate-on-chameleon.md
@@ -78,6 +78,7 @@ To run the Ansible playbook (run in `kubespray` directory):
 ```bash
 ansible-playbook -i inventory/<CLUSTER_NAME>/hosts.yaml --become --become-user=root -u <SSH_USER> cluster.yml
 ```
+{:data-add-copy-button='true'}
 
 This playbook will take a while to run (around 10 minutes, depending).
 Once it has finished, login to the node and run `sudo kubectl get nodes`.
@@ -104,6 +105,7 @@ ansible-playbook -i /path/to/kubespray/inventory/<CLUSTER_NAME>/hosts.yaml -u <S
  -e 'slate_enable_ingress=false' \
  site.yml
 ```
+{:data-add-copy-button='true'}
 
 After this command runs, you should have a SLATE cluster!
 Run `slate cluster list`, and if everything was successful, you should see your cluster listed in the output.
@@ -126,6 +128,7 @@ To install the ingress controller, login to a cluster node with `kubectl` access
 ```bash
 curl -o deploy.yaml https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.44.0/deploy/static/provider/baremetal/deploy.yaml
 ```
+{:data-add-copy-button='true'}
 
 Next, open this file with your preferred editor, and navigate to the line that contains this argument: `--ingress-class=nginx`
 Change this `ingress-class` parameter from `nginx` to `slate`. 
@@ -134,6 +137,7 @@ Finally, deploy the ingress controller with `kubectl`:
 ```bash
 sudo kubectl apply -f /path/to/deploy.yaml
 ```
+{:data-add-copy-button='true'}
 
 At this point, you will have an operational ingress controller. All that remains is to see which ports the ingress controller is running on. This can be done with `sudo kubectl get services -n ingress-nginx`. 
 You will see an `ingress-nginx-controller` NodePort service, with ports 80 and 443 mapped to two different high ports. One of these ports (80 is http, 443 is https) must be appended to any and all requests using the ingress controller.

--- a/_posts/2021-07-02-metallb-on-chameleon.md
+++ b/_posts/2021-07-02-metallb-on-chameleon.md
@@ -185,6 +185,7 @@ Use the following command to view a list of the IDs of your OpenStack/Chameleon 
 ```bash
 openstack port list
 ```
+{:data-add-copy-button='true'}
 
 You will see some output that looks similar to this:
 ```bash
@@ -202,6 +203,7 @@ Then, disable ARP-spoofing protection for each one of your MetalLB IP addresses 
 ```bash
 openstack port set <port-id> --allowed-address ip-address=<additional-ip-address>
 ```
+{:data-add-copy-button='true'}
 
 In our case, we need to run this command four times, once for each IP address we have set aside for MetalLB:
 ```bash
@@ -227,6 +229,7 @@ metallb_ip_range:
   - "192.168.1.251-192.168.1.254"
 metallb_version: v0.9.3
 ```
+{:data-add-copy-button='true'}
 *Note that if you have used a different private subnet, or reserved different IP addresses for MetalLB, you will need to change this configuration accordingly.*
 1. Configure strict ARP by changing these lines in inventory/<CLUSTER_NAME>/group_vars/k8s-cluster/k8s-cluster.yml from
 ```
@@ -236,6 +239,7 @@ to
 ```
 kube_proxy_strict_arp: true # Required for MetalLB
 ```
+{:data-add-copy-button='true'}
 
 Instructions for both of these things can be found in the [additional configurations](https://slateci.io/docs/cluster/automated/kubernetes-cluster-creation.html#additional-configurations) section of the docs.
 
@@ -243,6 +247,7 @@ To run the Ansible playbook (run in `kubespray` directory):
 ```bash
 ansible-playbook -i inventory/<CLUSTER_NAME>/hosts.yaml --become --become-user=root -u <SSH_USER> cluster.yml
 ```
+{:data-add-copy-button='true'}
 
 This playbook will take a while to run (around 15 minutes, depending).
 Once it has finished, login to the node and run `sudo kubectl get nodes`.
@@ -268,6 +273,7 @@ ansible-playbook -i /path/to/kubespray/inventory/<CLUSTER_NAME>/hosts.yaml -u <S
  -e 'cluster_access_ip=<EXTERNAL_NAT_IP>:6443' \
  site.yml
 ```
+{:data-add-copy-button='true'}
 
 After this command runs, you should have a SLATE cluster!
 Run `slate cluster list`, and if everything was successful, you should see your cluster listed in the output.
@@ -284,6 +290,7 @@ Make sure ingress is enabled in the `values.yaml`, and make a note of your chose
 ```bash
 sudo kubectl get services -n slate-system
 ```
+{:data-add-copy-button='true'}
 An `ingress-nginx` LoadBalancer will show up.
 Make a note of the `EXTERNAL-IP` value.
 It should be one of the IP addresses you allocated to MetalLB.
@@ -294,6 +301,7 @@ Then, run this command:
 ```bash
 curl -H "Host: <subdomain_name>.<your_cluster_name>.slateci.net" <load_balancer_external_ip>
 ```
+{:data-add-copy-button='true'}
 1. If everything was successful, you should see the following output:
 
 ```

--- a/_posts/2021-08-12-open-ondemand-desktop.md
+++ b/_posts/2021-08-12-open-ondemand-desktop.md
@@ -47,6 +47,7 @@ obtained. The SLATE client will do this with the following command:
 ```bash
 slate app get-conf open-ondemand > ood.yaml
 ```
+{:data-add-copy-button='true'}
 
 This will save a local copy of the OnDemand configuration, formatted as a
 .yaml file. We will modify this configuration accordingly, and eventually
@@ -128,6 +129,7 @@ then you may leave this field blank.
 ```bash
 kubectl label nodes <node-name> application=ood
 ```
+{:data-add-copy-button='true'}
 
 ### Secret_Generation
 
@@ -218,6 +220,7 @@ path as the `singularity_image` field in Cluster Definitions [above](###Cluster_
 ```bash
 singularity pull docker://centos:7
 ```
+{:data-add-copy-button='true'}
 
 To establish a remote desktop connection, ports 5800(+n) 5900(+n) and 6000(+n)
 need to be open for each display number n. As well as, port 22 for ssh
@@ -229,6 +232,7 @@ To do this easily, add a global rule to iptables or a firewalld exception.
 sudo iptables -A INPUT -s xxx.xxx.xxx.xxx/32 -j ACCEPT
 sudo firewall-cmd --zone=trusted --add-source=xxx.xxx.xxx.xxx/32
 ```
+{:data-add-copy-button='true'}
 
 ### Filesystem_Distribution
 
@@ -261,6 +265,7 @@ For more detailed information, see the links in [Prerequisites](##Prerequisites)
 ```bash
 ssh-keyscan [ONDEMAND_HOST_PUBLIC_IP] >> /etc/ssh/ssh_known_hosts
 ```
+{:data-add-copy-button='true'}
 
 Next, add an entry to `/etc/ssh/shosts.equiv` with the IP address of the
 OnDemand server like so
@@ -308,6 +313,7 @@ To install the application using slate, run this app install command:
 ```bash
 slate app install open-ondemand --group <group_name> --cluster <cluster_name> --conf /path/to/ood.yaml
 ```
+{:data-add-copy-button='true'}
 
 ## Testing
 
@@ -334,6 +340,7 @@ section for each user you would like to add:
     groupID: <1000+n>
     tempPassword: <temporary_password_here>
 ```
+{:data-add-copy-button='true'}
 
 ## Configurable_Parameters:
 

--- a/_posts/2021-08-24-perfsonar-checker.md
+++ b/_posts/2021-08-24-perfsonar-checker.md
@@ -54,6 +54,7 @@ To deploy the `perfsonar-checker` app, start by downloading the app configuratio
 ```
 slate app get-conf --dev perfsonar-checker > app.conf
 ```
+{:data-add-copy-button='true'}
 The default configuration should look something like:
 
 ```
@@ -93,6 +94,7 @@ To install your app instance, run the below command after substituting `<your-gr
 ```
 slate app install --dev --group <your-group> --cluster <cluster> perfsonar-checker --conf app.conf
 ``` 
+{:data-add-copy-button='true'}
 
 The above command would install an instance of the `perfsonar-checker` app under your group on the given target cluster using the configuration from `app.conf`. A successful run of the install command should print a message along with an `<instance-ID>` for your deployment as shown in the below example:
 
@@ -110,6 +112,7 @@ To view the summary output of the tests that have finished, run the below comman
 ```
 slate instance logs --max-lines 0 <instance-ID>
 ```
+{:data-add-copy-button='true'}
 
 The tests start by checking the status of the pscheduler services in your instance, so for a normal operation you will see the below instance log message:
 
@@ -177,6 +180,7 @@ To delete your deployed instance, run the below command along with your `<instan
 ```
 slate instance delete <instance-ID>
 ```
+{:data-add-copy-button='true'}
 
 
 ## Summary


### PR DESCRIPTION
There was no open issue for this. 

This pull request adds missing copy-to-clipboard buttons in _docs/ and _posts/ for slateci.io. This uses the existing logic from `containerd.md` on [slateci.io](https://slateci.io/docs/cluster/manual/containerd.html)

I struggled to add when the code block was wrapped in a `{%raw%}` tag, as happened in `features.md` and a couple of blog posts. If it's critical to add the buttons to these can I please have some help.