### PR TITLE
Fix copy button showing up on blog posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -24,3 +24,6 @@ layout: default
     </div>
   </div>
 </div>
+
+<script src="/js/clipboard.min.js"></script>
+<script src="/js/copy.js"></script>


### PR DESCRIPTION
There was no open issue for this. 

This pull request adds the requisite code to make the copy-to-clipboard buttons show up on blog posts on slateci.io. I added `<script src="/js/clipboard.min.js"></script>` and `<script src="/js/copy.js"></script>` to `post.html` in `_layouts`. This follows the logic used for `docs2020.html` to render the copy button on SLATE documentation. 

I tested this locally by running the site via Docker. 