### PR TITLE
Fix Scroll Jumping on Docs Pages

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -24,3 +24,6 @@ layout: default
     </div>
   </div>
 </div>
+
+<script src="/js/clipboard.min.js"></script>
+<script src="/js/copy.js"></script>

--- a/_sass/modules/_doc-nav.scss
+++ b/_sass/modules/_doc-nav.scss
@@ -67,8 +67,7 @@
 }
 
 .freeze-menu {
-	position: -webkit-sticky;
-  	position: sticky;
+	position: absolute;
   	top: 0;
 	left: 10px;
 }


### PR DESCRIPTION
Closes #181 

This pull request fixes the bug of the scroll jump on docs pages. The problem was with the position in the `.freeze-menu` being set to `-webkit-sticky` and `sticky`. I replaced those two lines with `position: absolute;`. 

I double-checked with Adam as well because he made the original changes to the `.freeze-menu` position. 