### PR TITLE
Update Copyright in Footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,7 +19,7 @@
 	  <p class="text-center">This material is based upon work supported by the National Science Foundation under Grant No. 1724821.<br>Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.</p>
 	  
           <p class="text-center w-100 my-3">
-            Copyright &copy; 2017-2020 SLATE CI<br>
+            Copyright &copy; 2017-{{ site.time | date: "%Y" }} SLATE CI<br>
             This site was built on {{ site.time | date: "%Y/%m/%d %H:%M" }}.
           </p>
         </div>


### PR DESCRIPTION
Closes #183 

The copyright in the footer was set to the year 2020. Instead of manually updating the year, I used Jekyll to create an automated update to the copyright year in the footer.

The tradeoff is that by using Jekyll, the year will update only when the website is rebuilt. If the website doesn't get rebuilt in 2023, then the year will still say 2022. 
If JavaScript had been used then it would automatically update the year without relying on rebuilding the site.  