### PR TITLE
Create Faucet & Telegraf Blog Posts + Command Typo Fix

### DIFF
--- a/_docs/cluster/manual/slate-master-node.md
+++ b/_docs/cluster/manual/slate-master-node.md
@@ -57,7 +57,7 @@ kubectl taint nodes --all node-role.kubernetes.io/master:NoSchedule-
 You might want to adjust the above command based on the role your Master Node holds. You can find this out by running:
 
 ```shell
-kubect get nodes
+kubectl get nodes
 ```
 {:data-add-copy-button='true'}
 

--- a/_posts/2023-01-03-faucet-rerelease-and-overview.md
+++ b/_posts/2023-01-03-faucet-rerelease-and-overview.md
@@ -11,6 +11,8 @@ type: markdown
 
 The SLATE Team is excited to announce the migration of Faucet from the incubator catalog to the stable catalog on the SLATE Portal. 
 
+<!--end_excerpt-->
+
 Faucet is an open source software defined networking (SDN) controller specifically designed for production networks. It is designed to make it easy for network administrators to manage and automate their networks, allowing them to quickly and easily implement changes and new policies.
 
 One of the key features of Faucet is its ability to support a wide range of networking hardware and protocols, including integration with Kubernetes. This makes it a versatile tool that can be used in a variety of different environments and networks, including those that are running on Kubernetes.

--- a/_posts/2023-01-03-faucet-rerelease-and-overview.md
+++ b/_posts/2023-01-03-faucet-rerelease-and-overview.md
@@ -1,0 +1,22 @@
+---
+title: Faucet Release and Application Overview
+overview: Faucet Release and Application Overview
+published: true
+permalink: blog/2023-01-03-faucet-rerelease-and-overview.html
+attribution: The SLATE Team
+layout: post
+type: markdown
+# tag: draft
+---
+
+The SLATE Team is excited to announce the migration of Faucet from the incubator catalog to the stable catalog on the SLATE Portal. 
+
+Faucet is an open source software defined networking (SDN) controller specifically designed for production networks. It is designed to make it easy for network administrators to manage and automate their networks, allowing them to quickly and easily implement changes and new policies.
+
+One of the key features of Faucet is its ability to support a wide range of networking hardware and protocols, including integration with Kubernetes. This makes it a versatile tool that can be used in a variety of different environments and networks, including those that are running on Kubernetes.
+
+Faucet is designed to be easy to use, with a simple and intuitive user interface that makes it easy for network administrators to get up and running quickly. It also comes with a range of powerful features, including support for VLANs, quality of service (QoS), and access control lists (ACLs).
+
+Overall, Faucet is a valuable tool for anyone looking to automate and manage their production network. Whether you are a network administrator at a large enterprise or conducting smaller research, Faucet can help you streamline your network management processes and improve the efficiency and performance of your network.
+
+To find an example of how to implement Faucet on your SLATE cluster, please see [this blog post](https://slateci.io/blog/slate-faucet-dec-2019.html)

--- a/_posts/2023-01-06-telegraf-rerelease-and-overview.md
+++ b/_posts/2023-01-06-telegraf-rerelease-and-overview.md
@@ -1,0 +1,22 @@
+---
+title: Telegraf Release and Application Overview
+overview: Telegraf Release and Application Overview
+published: true
+permalink: blog/2023-01-06-telegraf-rerelease-and-overview.html
+attribution: The SLATE Team
+layout: post
+type: markdown
+# tag: draft
+---
+
+The SLATE Team is excited to announce the migration of Telegraf from the incubator catalog to the stable catalog on the SLATE Portal. 
+
+Telegraf is an open source server agent that helps you collect metrics from your stacks, sensors, and systems. Developed by the Indiana University’s GlobalNOC, Telegraf is designed to be a lightweight and flexible tool that can be easily configured to collect a wide variety of metrics from a variety of sources.
+
+One of the key features of Telegraf is its ability to collect metrics from various sources, including servers, applications, databases, and other systems. It can be configured to collect metrics from popular systems like Linux, Windows, and MacOS, as well as from custom systems or devices. Telegraf can also be used to collect metrics from Kubernetes clusters and the applications running within them. This can be particularly useful for monitoring the health and performance of your Kubernetes resources, as well as identifying potential issues that may need to be addressed.
+
+In addition to collecting metrics from Kubernetes, Telegraf can also be used to send those metrics to a variety of data storage and visualization tools, such as InfluxDB, Graphite, and Elasticsearch. This allows you to store and analyze your Kubernetes metrics in a way that makes sense for your particular use case, and make informed decisions about your cluster and applications.
+
+Overall, Telegraf is a powerful tool that can help you collect and analyze metrics from your Kubernetes clusters and applications. Whether you are a system administrator looking to monitor the health and performance of your infrastructure, or a developer looking to gather metrics about your applications, Telegraf is a powerful tool that can help you get the insights you need to make informed decisions.
+
+To find an example of how to implement Telegraf on your SLATE cluster, please see [this blog post](https://slateci.io/blog/grnoc-telegraf-monitoring.html)

--- a/_posts/2023-01-06-telegraf-rerelease-and-overview.md
+++ b/_posts/2023-01-06-telegraf-rerelease-and-overview.md
@@ -11,6 +11,8 @@ type: markdown
 
 The SLATE Team is excited to announce the migration of Telegraf from the incubator catalog to the stable catalog on the SLATE Portal. 
 
+<!--end_excerpt-->
+
 Telegraf is an open source server agent that helps you collect metrics from your stacks, sensors, and systems. Developed by the Indiana University’s GlobalNOC, Telegraf is designed to be a lightweight and flexible tool that can be easily configured to collect a wide variety of metrics from a variety of sources.
 
 One of the key features of Telegraf is its ability to collect metrics from various sources, including servers, applications, databases, and other systems. It can be configured to collect metrics from popular systems like Linux, Windows, and MacOS, as well as from custom systems or devices. Telegraf can also be used to collect metrics from Kubernetes clusters and the applications running within them. This can be particularly useful for monitoring the health and performance of your Kubernetes resources, as well as identifying potential issues that may need to be addressed.


### PR DESCRIPTION
Created two new blog posts for moving Faucet and Telegraf to the stable catalog on SLATE Portal:
- what it is
- what it can do
- how to replicate it
Linked the installation/replication to previous Faucet and Telegraf blog posts.

Fixed a typo in the `kubectl get nodes` command shown on the SLATE Master Node docs page.