### PR TITLE
Broken Calico Linnk & Moved Telegraf To Draft

### DIFF
--- a/_docs/cluster/manual/slate-master-node.md
+++ b/_docs/cluster/manual/slate-master-node.md
@@ -81,7 +81,7 @@ kubectl create -f https://docs.projectcalico.org/manifests/custom-resources.yaml
 ```
 {:data-add-copy-button='true'}
 
-If you have changed the IP range to anything other than `192.168.0.0/16` in the `kubeadm init` command above, you will need to first download the boilerplate [custom-resources.yaml](https://docs.projectcalico.org/manifests/custom-resources.yaml) file from the Calico website then update its IP range under `spec/calicoNetwork/ipPools/blockSize` and `CIDR`. Finally, create the custom resources manifest:
+If you have changed the IP range to anything other than `192.168.0.0/16` in the `kubeadm init` command above, you will need to first download the boilerplate [custom-resources.yaml](https://github.com/projectcalico/calico/blob/master/manifests/custom-resources.yaml) file from Project Calico on GitHub, then update its IP range under `spec/calicoNetwork/ipPools/blockSize` and `CIDR`. Finally, create the custom resources manifest:
 
 ```shell
 kubectl create -f /path/to/custom-resources.yaml

--- a/_posts/2023-01-06-telegraf-rerelease-and-overview.md
+++ b/_posts/2023-01-06-telegraf-rerelease-and-overview.md
@@ -6,7 +6,7 @@ permalink: blog/2023-01-06-telegraf-rerelease-and-overview.html
 attribution: The SLATE Team
 layout: post
 type: markdown
-# tag: draft
+tag: draft
 ---
 
 The SLATE Team is excited to announce the migration of Telegraf from the incubator catalog to the stable catalog on the SLATE Portal. 


### PR DESCRIPTION
Selenium testing discovered a broken link for Calico's `custom-resources.yaml` in Manual Cluster Installation, so I have replaced it with an alternative. It appears the link has moved off the Calico website and into the Calico GitHub repository. 

Since the Telegraf app has been experiencing issues and was moved back to the incubator, the blog post about the release of Telegraf to the stable catalog has been drafted for now. 