### PR TITLE
Fix Calico Install Links

### DIFF
--- a/_docs/cluster/manual/slate-master-node.md
+++ b/_docs/cluster/manual/slate-master-node.md
@@ -70,14 +70,14 @@ In order to enable Pods to communicate with the rest of the cluster, you will ne
 To install Calico, you will simply need to apply the appropriate Kubernetes manifests beginning with the operator:
 
 ```shell
-kubectl create -f https://docs.projectcalico.org/manifests/tigera-operator.yaml
+kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/tigera-operator.yaml 
 ```
 {:data-add-copy-button='true'}
 
 If you haven't changed the default IP range then create the boilerplate custom resources manifest:
 
 ```shell
-kubectl create -f https://docs.projectcalico.org/manifests/custom-resources.yaml
+kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/custom-resources.yaml 
 ```
 {:data-add-copy-button='true'}
 


### PR DESCRIPTION
Closes #227 

The Manual Installation Guide relies on Calico to set up the [Pod Network](https://slateci.io/docs/cluster/manual/slate-master-node.html). However, the Calico links we relied on for tigera operator and custom resources creation [broke](https://docs.tigera.io/calico/3.25/manifests/tigera-operator.yaml) when Calico moved the yaml files from their website to their GitHub repository. 

This Calico for k8s quickstart guide indicated the [new location](https://docs.tigera.io/calico/3.25/getting-started/kubernetes/quickstart) of the yaml files. 

I have tested out the new links with a manual cluster installation and the Calico pods came up with the status `Running` and `Ready`.