### PR TITLE
Removed 'drafts' from RSS Feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -14,7 +14,7 @@ layout: null
       <link>{{home}}/index.html</link>
     </image>
     {% for post in site.posts %}
-      {% unless post.draft %}
+      {% unless post.tag == 'draft' %}
         <item>
           <title>{{ post.title | xml_escape }}</title>
           <description>{{ post.overview | xml_escape }}</description>


### PR DESCRIPTION
The RSS feed was presenting the blog posts marked with the `draft` tag and not filtering them out properly. This change removes that and will prevent drafts showing up on the Portal in "News". 