### PR TITLE
Remove Singularity From Technology Web Page

### DIFF
--- a/technology/index.md
+++ b/technology/index.md
@@ -49,19 +49,6 @@ type: markdown
 	</div>
 </div>
 
-<!-- <hr>
-
-<div class="row p-2">
-	<div class="col-2">
-		<img src="/img/singularity.png">
-	</div>
-	<div class="col-10">
-		<p>
-		<a href="https://sylabs.io/singularity">Singularity</a> can be run in place of Docker as an alternative container run-time environment for Kubernetes. Singularity adds additional security and features that have made it popular in many environments including HPC. To learn more about running a Kubernetes cluster with Singularity checkout our recent blog post: <a href="/blog/kubernetes-with-singularity.html">Setting up a Kubernetes Cluster based on Singularity</a>. 
-		</p>
-	</div>
-</div> -->
-
 <hr>
 
 <div class="row p-2">

--- a/technology/index.md
+++ b/technology/index.md
@@ -49,7 +49,7 @@ type: markdown
 	</div>
 </div>
 
-<hr>
+<!-- <hr>
 
 <div class="row p-2">
 	<div class="col-2">
@@ -60,7 +60,7 @@ type: markdown
 		<a href="https://sylabs.io/singularity">Singularity</a> can be run in place of Docker as an alternative container run-time environment for Kubernetes. Singularity adds additional security and features that have made it popular in many environments including HPC. To learn more about running a Kubernetes cluster with Singularity checkout our recent blog post: <a href="/blog/kubernetes-with-singularity.html">Setting up a Kubernetes Cluster based on Singularity</a>. 
 		</p>
 	</div>
-</div>
+</div> -->
 
 <hr>
 


### PR DESCRIPTION
Closes #103 

On the SLATE website, Singularity was offered as an alternative container runtime to Docker. However, the Singularity CRI repository has been [archived](https://github.com/sylabs/singularity-cri) by its owners and the service is now deprecated. 